### PR TITLE
Expose additional gRPC CLI arguments

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -278,6 +278,9 @@ enum TritonOptionId {
   OPTION_GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS,
   OPTION_GRPC_ARG_HTTP2_MAX_PING_STRIKES,
   OPTION_GRPC_RESTRICTED_PROTOCOL,
+  OPTION_GRPC_RESOURCE_QUOTA_MAX_THREADS,
+  OPTION_GRPC_RESOURCE_QUOTA_MAX_SIZE,
+  OPTION_GRPC_ARG_MAX_CONCURRENT_STREAMS,
 #endif  // TRITON_ENABLE_GRPC
 #if defined(TRITON_ENABLE_SAGEMAKER)
   OPTION_ALLOW_SAGEMAKER,
@@ -478,6 +481,15 @@ std::vector<Option> TritonParser::recognized_options_
        "<protocol> is a comma-separated list of protocols to be restricted. "
        "<key> will be additional header key to be checked when a GRPC request "
        "is received, and <value> is the value expected to be matched."},
+      {OPTION_GRPC_ARG_MAX_CONCURRENT_STREAMS, "grpc-max-concurrent-streams",
+       Option::ArgInt,
+       "Maximum number of concurrent incoming streams to allow on a http2 connection."},
+      {OPTION_GRPC_RESOURCE_QUOTA_MAX_SIZE, "grpc-resource-quota-max-memory-bytes",
+       Option::ArgInt,
+       "Maximum memory usage by the gRPC server."},
+      {OPTION_GRPC_RESOURCE_QUOTA_MAX_THREADS, "grpc-resource-quota-max-threads",
+       Option::ArgInt,
+       "Maximum number of threads used by the gRPC server."},
 #endif  // TRITON_ENABLE_GRPC
 #if defined(TRITON_ENABLE_SAGEMAKER)
       {OPTION_ALLOW_SAGEMAKER, "allow-sagemaker", Option::ArgBool,
@@ -1241,6 +1253,15 @@ TritonParser::Parse(int argc, char** argv)
       }
       case OPTION_GRPC_HEADER_FORWARD_PATTERN:
         lgrpc_options.forward_header_pattern_ = optarg;
+        break;
+      case OPTION_GRPC_ARG_MAX_CONCURRENT_STREAMS:
+        lgrpc_options.max_concurrent_streams_ = ParseOption<int>(optarg);
+        break;
+      case OPTION_GRPC_RESOURCE_QUOTA_MAX_SIZE:
+        lgrpc_options.resource_quota_max_size_ = ParseOption<long>(optarg);
+        break;
+      case OPTION_GRPC_RESOURCE_QUOTA_MAX_THREADS:
+        lgrpc_options.resource_quota_max_threads_ = ParseOption<int>(optarg);
         break;
 #endif  // TRITON_ENABLE_GRPC
 

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -2290,6 +2290,20 @@ Server::Server(
   builder_.AddChannelArgument(
       GRPC_ARG_ALLOW_REUSEPORT, options.socket_.reuse_port_);
 
+  if (options.max_concurrent_streams_ > 0) {
+    builder_.AddChannelArgument(
+        GRPC_ARG_MAX_CONCURRENT_STREAMS, options.max_concurrent_streams_);
+  }
+
+  ::grpc::ResourceQuota rq("triton");
+  if (options.resource_quota_max_size_ > 0) {
+    rq.Resize(options.resource_quota_max_size_);
+  }
+  if (options.resource_quota_max_threads_ > 0) {
+    rq.SetMaxThreads(options.resource_quota_max_threads_);
+  }
+  builder_.SetResourceQuota(rq);
+
   {
     // GRPC KeepAlive Docs:
     // https://grpc.github.io/grpc/cpp/md_doc_keepalive.html NOTE: In order to

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -90,6 +90,9 @@ struct Options {
   int infer_allocation_pool_size_{8};
   std::vector<ProtocolGroup> protocol_groups_{};
   std::string forward_header_pattern_;
+  int max_concurrent_streams_{0};
+  int resource_quota_max_threads_{0};
+  long resource_quota_max_size_{0};
 };
 
 class Server {


### PR DESCRIPTION
This PR adds some gRPC CLI arguments that can help prevent runaway memory usage under high load.