### PR TITLE
Disable gRPC request cancellation to fix segfault

### DIFF
--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1083,7 +1083,7 @@ class InferHandlerState {
 
   ~InferHandlerState() { ClearTraceTimestamps(); }
 
-  bool IsGrpcContextCancelled() { return context_->IsCancelled(); }
+  bool IsGrpcContextCancelled() { return false; }
 
   void Reset(
       const std::shared_ptr<Context>& context, Steps start_step = Steps::START)


### PR DESCRIPTION
I've been able to reliably induce immediate segfaults in Triton by setting a very low client-side request timeout of 2 ms. This behavior first appeared in r23.10, which introduced request cancellation. This PR disables request cancellation in the least intrusive way, so that we can easily cherry-pick this change later if needed. I've verified that the fix resolves the issue in that synthetic scenario. Note that we also are seeing sporadic segfaults at the tail end of our benchmarks. Since those are harder to reproduce, I'm not sure whether this change will fix those.